### PR TITLE
fix(neosnippet): Prevent keyError exception if not using neosnippet

### DIFF
--- a/rplugin/python3/deoplete/sources/flow.py
+++ b/rplugin/python3/deoplete/sources/flow.py
@@ -49,7 +49,7 @@ class Completer(object):
             return json['name']
             
         # If not using neosnippet
-        if not self.__vim.vars['neosnippet#enable_completed_snippet']:
+        if not self.__vim.vars.get('neosnippet#enable_completed_snippet'):
             return json['name'] + '('
 
         def buildArgumentList(arg):


### PR DESCRIPTION
When `neosnippet#enable_completed_snippet` is not defined (my case) `self.__vim.vars[neosnippet#enable_completed_snippet]` throws an exception that is not handled and makes deoplete crash. 