### PR TITLE
Add option to disable paren insertion when completing a function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ let g:neosnippet#enable_completed_snippet = 1
 
 ```
 
+## Configuration
+
+If neosnippet integration is not enabled, this plugin will insert an opening
+paren when completing a function name.
+Add this line to your configuration to disable that behavior:
+
+```vimL
+let g:autocomplete_flow#insert_paren_after_function = 0
+```
+
 ## Credits
 
 The initial version is based on [autocomplete-swift](https://github.com/mitsuse/autocomplete-swift). Thanks to @SeeThruHead for the vim script to find flow-bin.

--- a/plugin/deoplete-flow.vim
+++ b/plugin/deoplete-flow.vim
@@ -14,3 +14,9 @@ if executable(local_flow)
 else
   let g:autocomplete_flow#flowbin = 'flow'
 endif
+
+" If the user does not use neosnippet, insert a paren when completing a function
+" name by default
+if !exists("g:autocomplete_flow#insert_paren_after_function")
+  let g:autocomplete_flow#insert_paren_after_function = 1
+endif

--- a/rplugin/python3/deoplete/sources/flow.py
+++ b/rplugin/python3/deoplete/sources/flow.py
@@ -50,7 +50,10 @@ class Completer(object):
             
         # If not using neosnippet
         if not self.__vim.vars.get('neosnippet#enable_completed_snippet'):
-            return json['name'] + '('
+            if self.__vim.vars.get('autocomplete_flow#insert_paren_after_function'):
+                return json['name'] + '('
+            else:
+                return json['name']
 
         def buildArgumentList(arg):
             index, paramDesc = arg


### PR DESCRIPTION
Thanks for the great plugin! I was struggling with deoplete configuration until I switched to your plugin, and things just started working.

The one issue I have is that I do not like the opening paren insertion when completing a function name. I use the 'kana/vim-smartinput' plugin to automatically insert a closing paren when I type an opening paren. Having an opening paren with no closing paren kinda disrupts my usual flow. And it is slightly irritating to have a paren added in cases where I want to reference a function without calling it (e.g., when passing a function as an argument to another function).